### PR TITLE
Remove breaking backticks in code example in _index.md

### DIFF
--- a/content/book/getting-started/_index.md
+++ b/content/book/getting-started/_index.md
@@ -186,14 +186,11 @@ and then the following should work
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"
 rustflags = []
-```
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
 #[profile.dev]
 #debug = 1
-```
-
 
 ## simple game with `setup`
 


### PR DESCRIPTION
TOML code example had extraneous backticks causing a code section to render as a bunch of titles and plain flowed text, against obvious intention.

This change removes the offending backticks.