### PR TITLE
Fix formatting in getting-started page, "Optimizations in debug builds" section.

### DIFF
--- a/content/book/getting-started/_index.md
+++ b/content/book/getting-started/_index.md
@@ -188,12 +188,13 @@ linker = "rust-lld.exe"
 rustflags = []
 ```
 
-# Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
-# In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
+Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
+In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
+
+```toml
 #[profile.dev]
 #debug = 1
 ```
-
 
 ## simple game with `setup`
 

--- a/content/book/getting-started/_index.md
+++ b/content/book/getting-started/_index.md
@@ -192,8 +192,8 @@ Optional: Uncommenting the following improves compile times, but reduces the amo
 In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
 
 ```toml
-#[profile.dev]
-#debug = 1
+# [profile.dev]
+# debug = 1
 ```
 
 ## simple game with `setup`


### PR DESCRIPTION
Hey, the formatting seemed a bit off on the "Optimizations in debug builds" section of the getting started page.
This fixes it and leaves it as I believe was intended in the first place.

Before:
![Image](https://github.com/darthdeus/comfy-website/assets/66457708/ed2a5d0c-af61-4377-b46c-4fb779b8c2cc)

After:
![image](https://github.com/darthdeus/comfy-website/assets/66457708/9488f6ef-4012-4ae6-bade-61fe44d15dab)

