### PR TITLE
Fix formatting on getting-started

### DIFF
--- a/content/book/getting-started/_index.md
+++ b/content/book/getting-started/_index.md
@@ -186,12 +186,11 @@ and then the following should work
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"
 rustflags = []
-```
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
-#[profile.dev]
-#debug = 1
+# [profile.dev]
+# debug = 1
 ```
 
 


### PR DESCRIPTION
I think this is most likely what was intended.

Currently:
<img width="1115" alt="Screenshot 2024-03-22 at 4 52 25 PM" src="https://github.com/darthdeus/comfy-website/assets/540048/b97d293f-f514-48b3-a8e9-c691946584d6">
