### PR TITLE
Update camera _index.md

### DIFF
--- a/content/book/camera/_index.md
+++ b/content/book/camera/_index.md
@@ -37,7 +37,7 @@ points to, or a zoom level, simply as follows:
 ```rust
 let mut camera = main_camera_mut();
 
-camera.position = vec2(5.0, 0.0);
+camera.center = vec2(5.0, 0.0);
 camera.zoom = 50.0;
 ```
 


### PR DESCRIPTION
The original said `camera.position` which does not exist as a field. Updated to use `camera.center` which does exist as a field.